### PR TITLE
[SN-721] build: support linio util v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.3",
-        "linio/util": "^2.2",
+        "linio/util": "^2.2|^3.0",
         "psr/log": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
The only breaking change of `linio/util` is that now supports only PHP 7.4.
If we want to support PHP version 7.1 and greater and `linio/util` v3 at the same time, we have to support both versions of `util` package.