### PR TITLE
chore: Docker compose improvment

### DIFF
--- a/docker-compose.cli.yml
+++ b/docker-compose.cli.yml
@@ -13,6 +13,7 @@ services:
     init: true
     volumes:
       - .:/application
+      - ./docker/php.ini:/usr/local/etc/php/conf.d/php.ini
     entrypoint: composer
 
   phpunit:
@@ -27,5 +28,6 @@ services:
     init: true
     volumes:
       - .:/application
+      - ./docker/php.ini:/usr/local/etc/php/conf.d/php.ini
     environment:
       LINIO_ENV: local

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,1 @@
+memory_limit = 512M


### PR DESCRIPTION
Add memory limit for docker-compose to fix problem with `dcli composer test`.