### PR TITLE
[SCP-1718] fix: add default value for salestype field

### DIFF
--- a/src/Model/Order/OrderItem.php
+++ b/src/Model/Order/OrderItem.php
@@ -235,7 +235,7 @@ class OrderItem implements JsonSerializable
         ?DateTimeImmutable $createdAt,
         ?DateTimeImmutable $updatedAt,
         ?string $returnStatus,
-        ?string $salesType
+        ?string $salesType = null
     ): OrderItem {
         $orderItem = new static();
 


### PR DESCRIPTION
Coverage:
gsc-master:
```
  Classes: 94.12% (112/119)  
  Methods: 97.97% (531/542)  
  Lines:   93.54% (2952/3156)
```
fix/scp-1718-add-default-value-for-salestype  
```
  Classes: 94.12% (112/119)  
  Methods: 97.97% (531/542)  
  Lines:   93.54% (2952/3156)
```