### PR TITLE
[SCP-1830] feat: change orderNumber to allow int or string

### DIFF
--- a/src/Factory/Xml/Order/OrderFactory.php
+++ b/src/Factory/Xml/Order/OrderFactory.php
@@ -70,9 +70,11 @@ class OrderFactory
             throw new InvalidDomainException('OperatorCode');
         }
 
+        $orderNumber = is_numeric((string) $element->OrderNumber) ? (int) $element->OrderNumber : (string) $element->OrderNumber;
+
         return Order::fromData(
             (int) $element->OrderId,
-            (int) $element->OrderNumber,
+            $orderNumber,
             (string) $element->CustomerFirstName,
             (string) $element->CustomerLastName,
             (string) $element->PaymentMethod,

--- a/src/Model/Order/Order.php
+++ b/src/Model/Order/Order.php
@@ -26,7 +26,7 @@ class Order implements JsonSerializable
     protected $customerLastName;
 
     /**
-     * @var int
+     * @var string|int
      */
     protected $orderNumber;
 
@@ -127,10 +127,11 @@ class Order implements JsonSerializable
 
     /**
      * @param string[] $statuses
+     * @param string|int $orderNumber
      */
     public static function fromData(
         int $orderId,
-        int $orderNumber,
+        $orderNumber,
         ?string $customerFirstName,
         ?string $customerLastName,
         string $paymentMethod,
@@ -180,12 +181,15 @@ class Order implements JsonSerializable
         return $order;
     }
 
-    public static function fromItems(int $orderId, int $orderNumber, OrderItems $orderItems): Order
+    /**
+     * @param string|int $orderNumber
+     */
+    public static function fromItems(int $orderId, $orderNumber, OrderItems $orderItems): Order
     {
         $order = new self();
 
         $order->orderId = $orderId;
-        $order->orderNumber = $orderNumber;
+        $order->orderNumber = is_numeric($orderNumber) ? (int) $orderNumber : (string) $orderNumber;
         $order->orderItems = $orderItems;
 
         return $order;
@@ -206,7 +210,10 @@ class Order implements JsonSerializable
         return $this->customerLastName;
     }
 
-    public function getOrderNumber(): int
+    /**
+     * @return string|int
+     */
+    public function getOrderNumber()
     {
         return $this->orderNumber;
     }

--- a/tests/Unit/Order/OrderTest.php
+++ b/tests/Unit/Order/OrderTest.php
@@ -21,6 +21,7 @@ class OrderTest extends LinioTestCase
     protected $customerFirstName = 'first_name+4632913';
     protected $customerLastName = 'last_name';
     protected $orderNumber = 204527353;
+    protected $globalOrderNumber = 'd060396b-826f-4ea8-83c0-3c6714a61785';
     protected $paymentMethod = 'CashOnDelivery_Payment';
     protected $remarks = 'someRemark';
     protected $deliveryInfo = 'someDeliveryInfo';
@@ -126,9 +127,13 @@ class OrderTest extends LinioTestCase
         OrderFactory::make($simpleXml);
     }
 
-    public function testItReturnsAJsonRepresentation(): void
+    /**
+     * @dataProvider DataVariations
+     */
+    public function testItReturnsAJsonRepresentation(string $property): void
     {
         $simpleXml = simplexml_load_string($this->createXmlStringForAOrder());
+        $simpleXml->OrderNumber = $this->{$property};
 
         $order = OrderFactory::make($simpleXml);
 
@@ -136,7 +141,7 @@ class OrderTest extends LinioTestCase
         $expectedJson['orderId'] = $this->orderId;
         $expectedJson['customerFirstName'] = $this->customerFirstName;
         $expectedJson['customerLastName'] = $this->customerLastName;
-        $expectedJson['orderNumber'] = $this->orderNumber;
+        $expectedJson['orderNumber'] = $this->{$property};
         $expectedJson['paymentMethod'] = $this->paymentMethod;
         $expectedJson['remarks'] = $this->remarks;
         $expectedJson['deliveryInfo'] = $this->deliveryInfo;
@@ -253,6 +258,14 @@ class OrderTest extends LinioTestCase
             ['PromisedShippingTime'],
             ['ExtraAttributes'],
             ['Statuses'],
+        ];
+    }
+
+    public function dataVariations(): array
+    {
+        return [
+            ['orderNumber'],
+            ['globalOrderNumber'],
         ];
     }
 }


### PR DESCRIPTION
Coverage:
gsc-master-dev:
```
  Classes: 95.08% (116/122)  
  Methods: 98.19% (544/554)  
  Lines:   94.06% (3276/3483)
```
feat/scp-1830-gsc-sdk-adapt-order-number:
```
  Classes: 95.08% (116/122)  
  Methods: 98.19% (544/554)  
  Lines:   94.06% (3277/3484)
```