### PR TITLE
[SCP-2513] enable null national registration number in SDK

### DIFF
--- a/src/Factory/Xml/Order/OrderFactory.php
+++ b/src/Factory/Xml/Order/OrderFactory.php
@@ -31,7 +31,6 @@ class OrderFactory
         'AddressUpdatedAt',
         'AddressBilling',
         'AddressShipping',
-        'NationalRegistrationNumber',
         'PromisedShippingTime',
         'ItemsCount',
         'ExtraAttributes',
@@ -59,6 +58,8 @@ class OrderFactory
 
         $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', (string) $element->PromisedShippingTime);
         $promisedShippingTime = !empty($dateTime) ? $dateTime : null;
+
+        $nationalRegistrationNumber = !empty($element->NationalRegistrationNumber) ? (string) $element->NationalRegistrationNumber : null;
 
         $statuses = [];
         foreach ($element->Statuses->Status as $status) {
@@ -89,7 +90,7 @@ class OrderFactory
             $addressUpdatedAt,
             $addressBilling,
             $addressShipping,
-            (string) $element->NationalRegistrationNumber,
+            $nationalRegistrationNumber,
             (int) $element->ItemsCount,
             $promisedShippingTime,
             (string) $element->ExtraAttributes,

--- a/src/Model/Order/Order.php
+++ b/src/Model/Order/Order.php
@@ -146,7 +146,7 @@ class Order implements JsonSerializable
         ?DateTimeInterface $addressUpdatedAt,
         Address $addressBilling,
         Address $addressShipping,
-        string $nationalRegistrationNumber,
+        ?string $nationalRegistrationNumber,
         int $itemsCount,
         ?DateTimeInterface $promisedShippingTime,
         ?string $extraAttributes,

--- a/tests/Unit/Order/OrderTest.php
+++ b/tests/Unit/Order/OrderTest.php
@@ -265,7 +265,6 @@ class OrderTest extends LinioTestCase
             ['AddressUpdatedAt'],
             ['AddressBilling'],
             ['AddressShipping'],
-            ['NationalRegistrationNumber'],
             ['ItemsCount'],
             ['PromisedShippingTime'],
             ['ExtraAttributes'],


### PR DESCRIPTION
feat/SCP-2513-enable-null-national-registration-number
```
Code Coverage Report Summary:
  Classes: 94.35% (117/124)
  Methods: 98.09% (564/575)
  Lines:   94.21% (3384/3592)
```

gsc-master-dev
```

Code Coverage Report Summary:
  Classes: 94.35% (117/124)
  Methods: 98.09% (564/575)
  Lines:   94.21% (3384/3592)
```