### PR TITLE
[SCP-2650] fix: gsc sdk products with more than 7 images are discarded

### DIFF
--- a/src/Model/Product/Images.php
+++ b/src/Model/Product/Images.php
@@ -7,7 +7,7 @@ namespace Linio\SellerCenter\Model\Product;
 use JsonSerializable;
 use Linio\SellerCenter\Contract\CollectionInterface;
 use Linio\SellerCenter\Exception\MaxImagesExceededException;
-
+use Monolog\Logger;
 class Images implements CollectionInterface, JsonSerializable
 {
     public const MAX_IMAGES_ALLOWED = 8;
@@ -27,10 +27,6 @@ class Images implements CollectionInterface, JsonSerializable
 
     public function add(Image $image): void
     {
-        if (count($this->collection) >= self::MAX_IMAGES_ALLOWED) {
-            throw new MaxImagesExceededException(self::MAX_IMAGES_ALLOWED);
-        }
-
         $this->collection[] = $image;
     }
 

--- a/src/Model/Product/Images.php
+++ b/src/Model/Product/Images.php
@@ -6,8 +6,7 @@ namespace Linio\SellerCenter\Model\Product;
 
 use JsonSerializable;
 use Linio\SellerCenter\Contract\CollectionInterface;
-use Linio\SellerCenter\Exception\MaxImagesExceededException;
-use Monolog\Logger;
+
 class Images implements CollectionInterface, JsonSerializable
 {
     public const MAX_IMAGES_ALLOWED = 8;

--- a/tests/Unit/Product/ImagesTest.php
+++ b/tests/Unit/Product/ImagesTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\SellerCenter\Product;
 
-use Linio\SellerCenter\Exception\MaxImagesExceededException;
 use Linio\SellerCenter\Factory\Xml\Product\ImagesFactory;
 use Linio\SellerCenter\LinioTestCase;
 use Linio\SellerCenter\Model\Product\Image;

--- a/tests/Unit/Product/ImagesTest.php
+++ b/tests/Unit/Product/ImagesTest.php
@@ -79,22 +79,6 @@ class ImagesTest extends LinioTestCase
     /**
      * @dataProvider generatedImages
      */
-    public function testItThrowsAnExceptionByOverflow(array $imageStack): void
-    {
-        $this->expectException(MaxImagesExceededException::class);
-        $this->expectExceptionMessage(sprintf('Only %s are supported into the collection.', Images::MAX_IMAGES_ALLOWED));
-
-        $availableImages = array_slice($imageStack, 0, Images::MAX_IMAGES_ALLOWED);
-        $image = array_slice($imageStack, 8, 1)[0];
-
-        $images = new Images();
-        $images->addMany($availableImages);
-        $images->add($image);
-    }
-
-    /**
-     * @dataProvider generatedImages
-     */
     public function testItSkipsAddingManyWithAFullyStackOfImages(array $imageStack): void
     {
         $availableImages = array_slice($imageStack, 0, Images::MAX_IMAGES_ALLOWED);


### PR DESCRIPTION
Coverage:
Current branch:
```
Code Coverage Report Summary:
  Classes: 93.55% (116/124)  
  Methods: 97.91% (563/575)  
  Lines:   94.10% (3379/3591)
```

gsc-master-dev branch:

```
Code Coverage Report Summary:
  Classes: 94.35% (117/124)  
  Methods: 98.09% (564/575)  
  Lines:   94.21% (3384/3592)
```
