### PR TITLE
[SCP3652]  feat: add operatorCode attribute in jsonSerialize method to enable serialization

### DIFF
--- a/src/Model/Order/Order.php
+++ b/src/Model/Order/Order.php
@@ -346,6 +346,7 @@ class Order implements JsonSerializable
         $serialized->extraAttributes = $this->extraAttributes;
         $serialized->statuses = $this->statuses;
         $serialized->orderItems = $this->orderItems;
+        $serialized->operatorCode = $this->operatorCode;
 
         return $serialized;
     }

--- a/src/Service/GlobalOrderManager.php
+++ b/src/Service/GlobalOrderManager.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Linio\SellerCenter\Service;
 
 use Linio\Component\Util\Json;
+use Linio\SellerCenter\Exception\InvalidDomainException;
+use Linio\SellerCenter\Factory\Xml\FeedResponseFactory;
+use Linio\SellerCenter\Factory\Xml\Order\OrderItemsFactory;
 use Linio\SellerCenter\Model\Order\OrderItem;
 use Linio\SellerCenter\Response\FeedResponse;
 use Linio\SellerCenter\Response\SuccessResponse;
-use Linio\SellerCenter\Factory\Xml\FeedResponseFactory;
-use Linio\SellerCenter\Exception\InvalidDomainException;
-use Linio\SellerCenter\Factory\Xml\Order\OrderItemsFactory;
 
 class GlobalOrderManager extends BaseOrderManager
 {
     const ALLOWED_INVOICE_TYPE = [
-      'BOLETA', 
-      'NOTA_DE_CREDITO'
+        'BOLETA',
+        'NOTA_DE_CREDITO',
     ];
 
     /**
@@ -73,7 +73,7 @@ class GlobalOrderManager extends BaseOrderManager
         $parameters->set([
             'OrderItemIds' => Json::encode($orderItemIds),
             'InvoiceNumber' => $invoiceNumber,
-            'InvoiceType' => $upperInvoiceType
+            'InvoiceType' => $upperInvoiceType,
         ]);
 
         $response = $this->executeAction(

--- a/tests/Unit/Order/OrderTest.php
+++ b/tests/Unit/Order/OrderTest.php
@@ -180,6 +180,7 @@ class OrderTest extends LinioTestCase
         $expectedJson['extraAttributes'] = $this->extraAttributes;
         $expectedJson['statuses'][0] = $this->statuses[0];
         $expectedJson['statuses'][1] = $this->statuses[1];
+        $expectedJson['operatorCode'] = $this->operatorCode;
 
         $this->assertJsonStringEqualsJsonString(Json::encode($expectedJson), Json::encode($order));
     }

--- a/tests/_schemas/Order/OrderWithOrderItems.json
+++ b/tests/_schemas/Order/OrderWithOrderItems.json
@@ -20,6 +20,7 @@
   "promisedShippingTime": null,
   "extraAttributes": null,
   "statuses": null,
+  "operatorCode": null,
   "orderItems": [
     {
       "orderItemId": "%d",


### PR DESCRIPTION
**Current branch:**

```
Code Coverage Report Summary:
  Classes: 97.01% (130/134)  
  Methods: 99.37% (628/632)  
  Lines:   99.61% (3029/3041)
```

**Master branch:**

```
Code Coverage Report Summary:
  Classes: 97.01% (130/134)  
  Methods: 99.37% (628/632)  
  Lines:   99.61% (3028/3040)
```
