### PR TITLE
fix: change order id to string

### DIFF
--- a/src/Factory/Xml/Order/OrderFactory.php
+++ b/src/Factory/Xml/Order/OrderFactory.php
@@ -83,7 +83,7 @@ class OrderFactory
             );
 
         return Order::fromData(
-            (int) $element->OrderId,
+            (string) $element->OrderId,
             $orderNumber,
             (string) $element->CustomerFirstName,
             (string) $element->CustomerLastName,

--- a/src/Factory/Xml/Order/OrderItemFactory.php
+++ b/src/Factory/Xml/Order/OrderItemFactory.php
@@ -83,7 +83,7 @@ class OrderItemFactory
         return OrderItem::fromOrderItem(
             (int) $element->OrderItemId,
             (int) $element->ShopId,
-            (int) $element->OrderId,
+            (string) $element->OrderId,
             (string) $element->Name,
             (string) $element->Sku,
             (string) $element->Variation,

--- a/src/Factory/Xml/Order/OrdersItemsFactory.php
+++ b/src/Factory/Xml/Order/OrdersItemsFactory.php
@@ -27,7 +27,7 @@ class OrdersItemsFactory
 
             $orderItems = OrderItemsFactory::make($item);
 
-            $order = Order::fromItems((int) $item->OrderId, (int) $item->OrderNumber, $orderItems);
+            $order = Order::fromItems((string) $item->OrderId, (int) $item->OrderNumber, $orderItems);
             $orders->add($order);
         }
 

--- a/src/Model/Order/Order.php
+++ b/src/Model/Order/Order.php
@@ -11,7 +11,7 @@ use stdClass;
 class Order implements JsonSerializable
 {
     /**
-     * @var int
+     * @var string
      */
     protected $orderId;
 
@@ -140,7 +140,7 @@ class Order implements JsonSerializable
      * @param string|int $orderNumber
      */
     public static function fromData(
-        int $orderId,
+        string $orderId,
         $orderNumber,
         ?string $customerFirstName,
         ?string $customerLastName,
@@ -198,7 +198,7 @@ class Order implements JsonSerializable
     /**
      * @param string|int $orderNumber
      */
-    public static function fromItems(int $orderId, $orderNumber, OrderItems $orderItems): Order
+    public static function fromItems(string $orderId, $orderNumber, OrderItems $orderItems): Order
     {
         $order = new self();
 
@@ -209,7 +209,7 @@ class Order implements JsonSerializable
         return $order;
     }
 
-    public function getOrderId(): int
+    public function getOrderId(): string
     {
         return $this->orderId;
     }

--- a/src/Model/Order/OrderItem.php
+++ b/src/Model/Order/OrderItem.php
@@ -21,7 +21,7 @@ class OrderItem implements JsonSerializable
     protected $shopId;
 
     /**
-     * @var int|null
+     * @var string|null
      */
     protected $orderId;
 
@@ -211,7 +211,7 @@ class OrderItem implements JsonSerializable
     final public static function fromOrderItem(
         int $orderItemId,
         int $shopId,
-        int $orderId,
+        string $orderId,
         string $name,
         string $sku,
         string $variation,
@@ -334,7 +334,7 @@ class OrderItem implements JsonSerializable
         return $this->shopId;
     }
 
-    public function getOrderId(): ?int
+    public function getOrderId(): ?string
     {
         return $this->orderId;
     }

--- a/src/Model/Order/Orders.php
+++ b/src/Model/Order/Orders.php
@@ -18,7 +18,7 @@ class Orders implements CollectionInterface
         return $this->collection;
     }
 
-    public function findByOrderId(int $orderId): ?Order
+    public function findByOrderId(string $orderId): ?Order
     {
         if (!key_exists($orderId, $this->collection)) {
             return null;

--- a/src/Service/BaseOrderManager.php
+++ b/src/Service/BaseOrderManager.php
@@ -33,7 +33,7 @@ class BaseOrderManager extends BaseManager
     public const DEFAULT_DATE_FORMAT = 'Y-m-d\TH:i:s';
 
     public function getOrder(
-        int $orderId,
+        string $orderId,
         bool $debug = true
     ): Order {
         $action = 'GetOrder';
@@ -59,7 +59,7 @@ class BaseOrderManager extends BaseManager
      * @return OrderItem[]
      */
     public function getOrderItems(
-        int $orderId,
+        string $orderId,
         bool $debug = true
     ): array {
         $action = 'GetOrderItems';

--- a/tests/Functional/BaseOrderManagerTest.php
+++ b/tests/Functional/BaseOrderManagerTest.php
@@ -54,7 +54,7 @@ class BaseOrderManagerTest extends LinioTestCase
     {
         $sdkClient = $this->getSdkClient($this->getOrdersResponse('Order/OrderResponse.xml'));
 
-        $orderId = 4687503;
+        $orderId = '4687503';
 
         $result = $sdkClient->orders()->getOrder($orderId);
 
@@ -65,7 +65,7 @@ class BaseOrderManagerTest extends LinioTestCase
     {
         $sdkClient = $this->getSdkClient($this->getOrdersResponse('Order/OrderItemsResponse.xml'));
 
-        $orderId = 6750999;
+        $orderId = '6750999';
 
         $result = $sdkClient->orders()->getOrderItems($orderId);
 
@@ -448,7 +448,7 @@ class BaseOrderManagerTest extends LinioTestCase
         }
 
         $sdkClient->orders()->getOrderItems(
-            1,
+            '1',
             $debug
         );
     }

--- a/tests/Unit/Order/OrderItemTest.php
+++ b/tests/Unit/Order/OrderItemTest.php
@@ -15,7 +15,7 @@ class OrderItemTest extends LinioTestCase
 {
     protected $orderItemId = 6750999;
     protected $shopId = 7208215;
-    protected $orderId = 4758978;
+    protected $orderId = '4758978';
     protected $name = 'MEGIR 5006 RELOJ ACERO INOXIDABLE ROSA';
     protected $sku = 'DJFKLJOEDKLFJ';
     protected $variation = 'Talla Única';

--- a/tests/Unit/Order/OrderTest.php
+++ b/tests/Unit/Order/OrderTest.php
@@ -17,7 +17,7 @@ use Linio\SellerCenter\Model\Order\OrderItems;
 
 class OrderTest extends LinioTestCase
 {
-    protected $orderId = 4632913;
+    protected $orderId = '4632913';
     protected $customerFirstName = 'first_name+4632913';
     protected $customerLastName = 'last_name';
     protected $orderNumber = 204527353;
@@ -191,7 +191,7 @@ class OrderTest extends LinioTestCase
 
     public function testItReturnsAJsonRepresentationWithOrderItems(): void
     {
-        $orderId = 1;
+        $orderId = '1';
         $orderNumber = 1;
         $randomDigit = $this->getFaker()->randomDigitNotNull;
 

--- a/tests/Unit/Order/OrdersTest.php
+++ b/tests/Unit/Order/OrdersTest.php
@@ -24,7 +24,7 @@ class OrdersTest extends LinioTestCase
 
         $orderList = $orders->all();
 
-        $order = $orders->findByOrderId(4687808);
+        $order = $orders->findByOrderId('4687808');
 
         $this->assertInstanceOf(Orders::class, $orders);
         $this->assertInstanceOf(Order::class, $order);
@@ -44,7 +44,7 @@ class OrdersTest extends LinioTestCase
 
         $orderList = $orders->all();
 
-        $order = $orders->findByOrderId(4687808);
+        $order = $orders->findByOrderId('4687808');
 
         $this->assertInstanceOf(Orders::class, $orders);
         $this->assertInstanceOf(Order::class, $order);
@@ -63,7 +63,7 @@ class OrdersTest extends LinioTestCase
 
         $orders = OrdersFactory::make($simpleXml);
 
-        $order = $orders->findByOrderId(12);
+        $order = $orders->findByOrderId('12');
 
         $this->assertNull($order);
     }


### PR DESCRIPTION
current branch:

```
OK (829 tests, 2699 assertions)

Code Coverage Report Summary:
  Classes: 95.74% (135/141)  
  Methods: 98.94% (653/660)  
  Lines:   99.53% (3177/3192)
```

