### PR TITLE
[SCP-4927] feat: support name and description as null params

### DIFF
--- a/src/Model/Product/BaseProduct.php
+++ b/src/Model/Product/BaseProduct.php
@@ -141,7 +141,7 @@ abstract class BaseProduct implements JsonSerializable
         return $this->parentSku;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -161,7 +161,7 @@ abstract class BaseProduct implements JsonSerializable
         return $this->categories;
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }

--- a/src/Model/Product/Contract/ProductInterface.php
+++ b/src/Model/Product/Contract/ProductInterface.php
@@ -23,7 +23,7 @@ interface ProductInterface
 
     public function getParentSku(): ?string;
 
-    public function getName(): string;
+    public function getName(): ?string;
 
     public function getVariation(): ?string;
 
@@ -31,7 +31,7 @@ interface ProductInterface
 
     public function getCategories(): Categories;
 
-    public function getDescription(): string;
+    public function getDescription(): ?string;
 
     public function getBrand(): Brand;
 

--- a/src/Model/Product/GlobalProduct.php
+++ b/src/Model/Product/GlobalProduct.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linio\SellerCenter\Model\Product;
 
 use JsonSerializable;
+use Linio\SellerCenter\Exception\EmptyArgumentException;
 use Linio\SellerCenter\Model\Brand\Brand;
 use Linio\SellerCenter\Model\Category\Categories;
 use Linio\SellerCenter\Model\Category\Category;
@@ -145,6 +146,74 @@ class GlobalProduct extends BaseProduct implements JsonSerializable, ProductInte
 
         if (!empty($contentScore)) {
             $product->setContentScore($contentScore);
+        }
+
+        return $product;
+    }
+
+    /**
+     * @return static
+     */
+    public static function fromBasicDataWithNullableParams(
+        string $sellerSku,
+        ?string $name,
+        ?string $variation,
+        Category $primaryCategory,
+        ?string $description,
+        Brand $brand,
+        BusinessUnits $businessUnits,
+        ?string $productId,
+        ?string $taxClass,
+        ProductData $productData,
+        ?Images $images = null,
+        ?string $qcStatus = null,
+        ?int $contentScore = null
+    ): self {
+        if (empty($sellerSku)) {
+            throw new EmptyArgumentException('SellerSku');
+        }
+
+        $product = new static();
+
+        $product->setSellerSku($sellerSku);
+        $product->setPrimaryCategory($primaryCategory);
+        $product->setBrand($brand);
+        $product->setBusinessUnits($businessUnits);
+        $product->setProductData($productData);
+
+        $categories = new Categories();
+        $product->setCategories($categories);
+
+        if (!empty($variation)) {
+            $product->setVariation($variation);
+        }
+
+        if (!empty($productId)) {
+            $product->setProductId($productId);
+        }
+
+        if (!empty($taxClass)) {
+            $product->setTaxClass($taxClass);
+        }
+
+        if (!empty($images)) {
+            $product->attachImages($images);
+        }
+
+        if (!empty($qcStatus)) {
+            $product->setQcStatus($qcStatus);
+        }
+
+        if (!empty($contentScore)) {
+            $product->setContentScore($contentScore);
+        }
+
+        if (!empty($name)) {
+            $product->setName($name);
+        }
+
+        if (!empty($description)) {
+            $product->setDescription($description);
         }
 
         return $product;

--- a/tests/Unit/Product/GlobalProductTest.php
+++ b/tests/Unit/Product/GlobalProductTest.php
@@ -147,6 +147,40 @@ class GlobalProductTest extends LinioTestCase
         $this->assertInstanceOf(BusinessUnits::class, $product->getBusinessUnits());
     }
 
+    public function testItUpdatedsAGlobalProductWithNullablesParameters(): void
+    {
+        $product = GlobalProduct::fromBasicDataWithNullableParams(
+            $this->sellerSku,
+            null,
+            $this->variation,
+            $this->primaryCategory,
+            null,
+            $this->brand,
+            $this->businessUnits,
+            null,
+            null,
+            $this->productData,
+            $this->images,
+            null,
+            $this->contentScore
+        );
+
+        $this->assertInstanceOf(GlobalProduct::class, $product);
+        $this->assertEquals($product->getSellerSku(), $this->sellerSku);
+        $this->assertEquals($product->getName(), null);
+        $this->assertEquals($product->getVariation(), $this->variation);
+        $this->assertEquals($product->getPrimaryCategory(), $this->primaryCategory);
+        $this->assertEquals($product->getDescription(), null);
+        $this->assertEquals($product->getBrand(), $this->brand);
+        $this->assertEquals($product->getProductId(), null);
+        $this->assertEquals($product->getTaxClass(), null);
+        $this->assertEquals($product->getProductData(), $this->productData);
+        $this->assertEquals($product->getQcStatus(), null);
+        $this->assertEquals($product->getContentScore(), $this->contentScore);
+        $this->assertInstanceOf(Images::class, $product->getImages());
+        $this->assertInstanceOf(BusinessUnits::class, $product->getBusinessUnits());
+    }
+
     public function testItCreatesAGlobalProductWithMandatoryAndOptionalParameters(): void
     {
         $product = GlobalProduct::fromBasicData(


### PR DESCRIPTION
Current branch:

Code Coverage Report Summary:
  Classes: 95.30% (142/149)  
  Methods: 98.58% (696/706)  
  Lines:   99.32% (3373/3396)